### PR TITLE
Added font-awesome.css

### DIFF
--- a/MMM-forecast-io.js
+++ b/MMM-forecast-io.js
@@ -62,7 +62,7 @@ Module.register("MMM-forecast-io", {
   },
 
   getStyles: function () {
-    return ["weather-icons.css", "MMM-forecast-io.css"];
+    return ["font-awesome.css", "weather-icons.css", "MMM-forecast-io.css"];
   },
 
   shouldLookupGeolocation: function () {


### PR DESCRIPTION
Will fix the missing indoor temperature icon if no calender module is used.